### PR TITLE
alsa-mixer: Rework output port priorities

### DIFF
--- a/src/modules/alsa/mixer/paths/analog-output-headphones-2.conf
+++ b/src/modules/alsa/mixer/paths/analog-output-headphones-2.conf
@@ -18,7 +18,7 @@
 ; See analog-output.conf.common for an explanation on the directives
 
 [General]
-priority = 89
+priority = 98
 description-key = analog-output-headphones
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/analog-output-headphones.conf
+++ b/src/modules/alsa/mixer/paths/analog-output-headphones.conf
@@ -18,7 +18,7 @@
 ; See analog-output.conf.common for an explanation on the directives
 
 [General]
-priority = 90
+priority = 99
 description-key = analog-output-headphones
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/analog-output-lineout.conf
+++ b/src/modules/alsa/mixer/paths/analog-output-lineout.conf
@@ -14,7 +14,7 @@
 # along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
 
 [General]
-priority = 99
+priority = 80
 description-key = analog-output-lineout
 
 [Jack Line Out]

--- a/src/modules/alsa/mixer/paths/analog-output-speaker.conf
+++ b/src/modules/alsa/mixer/paths/analog-output-speaker.conf
@@ -18,7 +18,7 @@
 ; See analog-output.conf.common for an explanation on the directives
 
 [General]
-priority = 100
+priority = 79
 description-key = analog-output-speaker
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/analog-output.conf
+++ b/src/modules/alsa/mixer/paths/analog-output.conf
@@ -19,7 +19,7 @@
 ; See analog-output.conf.common for an explanation on the directives
 
 [General]
-priority = 99
+priority = 78
 
 [Element Hardware Master]
 switch = mute

--- a/src/modules/alsa/mixer/paths/analog-output.conf.common
+++ b/src/modules/alsa/mixer/paths/analog-output.conf.common
@@ -162,14 +162,14 @@ switch = off
 [Element Analog Output]
 enumeration = select
 
-[Option Analog Output:Speakers]
-name = output-speaker
-priority = 10
-
 [Option Analog Output:Headphones]
 name = output-headphones
-priority = 9
+priority = 10
 
 [Option Analog Output:FP Headphones]
 name = output-headphones
-priority = 8
+priority = 9
+
+[Option Analog Output:Speakers]
+name = output-speaker
+priority = 7

--- a/src/modules/alsa/mixer/paths/hdmi-output-0.conf
+++ b/src/modules/alsa/mixer/paths/hdmi-output-0.conf
@@ -1,6 +1,6 @@
 [General]
 description = HDMI / DisplayPort
-priority = 59
+priority = 89
 eld-device = 3
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/hdmi-output-1.conf
+++ b/src/modules/alsa/mixer/paths/hdmi-output-1.conf
@@ -1,6 +1,6 @@
 [General]
 description = HDMI / DisplayPort 2
-priority = 58
+priority = 88
 eld-device = 7
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/hdmi-output-2.conf
+++ b/src/modules/alsa/mixer/paths/hdmi-output-2.conf
@@ -1,6 +1,6 @@
 [General]
 description = HDMI / DisplayPort 3
-priority = 57
+priority = 87
 eld-device = 8
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/hdmi-output-3.conf
+++ b/src/modules/alsa/mixer/paths/hdmi-output-3.conf
@@ -1,6 +1,6 @@
 [General]
 description = HDMI / DisplayPort 4
-priority = 56
+priority = 86
 eld-device = 9
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/hdmi-output-4.conf
+++ b/src/modules/alsa/mixer/paths/hdmi-output-4.conf
@@ -1,6 +1,6 @@
 [General]
 description = HDMI / DisplayPort 5
-priority = 55
+priority = 85
 eld-device = 10
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/hdmi-output-5.conf
+++ b/src/modules/alsa/mixer/paths/hdmi-output-5.conf
@@ -1,6 +1,6 @@
 [General]
 description = HDMI / DisplayPort 6
-priority = 54
+priority = 84
 eld-device = 11
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/hdmi-output-6.conf
+++ b/src/modules/alsa/mixer/paths/hdmi-output-6.conf
@@ -1,6 +1,6 @@
 [General]
 description = HDMI / DisplayPort 7
-priority = 53
+priority = 83
 eld-device = 12
 
 [Properties]

--- a/src/modules/alsa/mixer/paths/hdmi-output-7.conf
+++ b/src/modules/alsa/mixer/paths/hdmi-output-7.conf
@@ -1,6 +1,6 @@
 [General]
 description = HDMI / DisplayPort 8
-priority = 52
+priority = 82
 eld-device = 13
 
 [Properties]


### PR DESCRIPTION
Implement the following precedence of ports on an ALSA card:

Headphones > HDMI > Line Out > Speakers > Default

Where "Default" is for cards which do not export controls with more
specific names.

https://phabricator.endlessm.com/T15601