### PR TITLE
Disable oFono backend

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,7 +22,7 @@ DEB_CONFIGURE_EXTRA_FLAGS = --enable-x11 --disable-hal-compat \
   --with-zsh-completion-dir=\$${datadir}/zsh/vendor-completions \
   --with-bash-completion-dir=\$${datadir}/bash-completion/completions \
   --with-systemduserunitdir=\$${prefix}/lib/systemd/user \
-  --disable-bluez4
+  --disable-bluez4 --disable-bluez5-ofono-headset
 
 
 PA_MAJORMINOR = $(shell echo $(DEB_VERSION_UPSTREAM) | sed -r -e 's/^([0-9]+\.[0-9]+).*/\1/')


### PR DESCRIPTION
Since PulseAudio 11 both the oFono and the native Bluetooth headset
backends are loaded in parallel, with the oFono backend being preferred
and the native used as a fallback. This leads to the following message
being printed on systems that don't ship oFono:

 [pulseaudio] backend-ofono.c: Failed to register as a handsfree audio
 agent with ofono: org.freedesktop.DBus.Error.ServiceUnknown: The name
 org.ofono was not provided by any .service files

Since we don't ship oFono on EOS and likely never will, we can disable
the oFono backend on compile time.

https://phabricator.endlessm.com/T21740