### PR TITLE
fixup! module-switch-on-port-available: Consider current profile before switching to a new one

### DIFF
--- a/src/modules/module-switch-on-port-available.c
+++ b/src/modules/module-switch-on-port-available.c
@@ -127,8 +127,10 @@ static int try_to_switch_profile(pa_device_port *port) {
     /* We don't want to switch to another profile automatically if the currently
        active profile has a higher priority than whatever profile would be selected
        in the loop below, but only if it contains at least one available port */
-    if (pa_card_profile_contains_type_ports(port->card->active_profile, port->direction, PA_AVAILABLE_YES))
+    if (pa_card_profile_contains_type_ports(port->card->active_profile, port->direction, PA_AVAILABLE_YES)) {
         best_profile = port->card->active_profile;
+        best_prio = port->card->active_profile->priority;
+    }
 
     PA_HASHMAP_FOREACH(profile, port->profiles, state) {
         bool good = false;


### PR DESCRIPTION
We need to save the priority from the current active profile if we want
to compare it with the priority of other profiles.

https://phabricator.endlessm.com/T23338