### PR TITLE
alsa-card: Fix crash when trying to move away from unavailable profile

### DIFF
--- a/src/modules/alsa/module-alsa-card.c
+++ b/src/modules/alsa/module-alsa-card.c
@@ -774,6 +774,9 @@ static pa_hook_result_t card_profile_available_changed(pa_core *c, pa_card_profi
     pa_assert(profile);
     pa_assert_se(card = profile->card);
 
+    if (!card->active_profile)
+        return PA_HOOK_OK;
+
     if (profile->available != PA_AVAILABLE_NO)
         return PA_HOOK_OK;
 


### PR DESCRIPTION
We previously introduced logic to switch to a different profile if the
active profile of a card became unavailable, on the following commit:

 commit 168036604b3634fc5ad850ed4f4630baf4d6052c
 Author: João Paulo Rechi Vita <jprvita@endlessm.com>
 Date:   Mon Aug 6 10:18:25 2018 -0700

 alsa-card: Switch profile when the active one becomes unavailable

But in that commit there was no check if there is an active profile at
the moment the callback is called, in which case it leads to a null
pointer dereference. This commit fixes that problem simply by checking
card->profile before dereferencing it.

https://phabricator.endlessm.com/T24603