### PR TITLE
core: Do not choose an unliked sink/source as default

### DIFF
--- a/src/pulsecore/core.c
+++ b/src/pulsecore/core.c
@@ -311,12 +311,12 @@ static int compare_sinks(pa_sink *a, pa_sink *b) {
 }
 
 void pa_core_update_default_sink(pa_core *core) {
-    pa_sink *best, *old, *sink;
+    pa_sink *best = NULL;
+    pa_sink *sink;
     uint32_t idx;
+    pa_sink *old;
 
     pa_assert(core);
-
-    best = old = core->default_sink;
 
     PA_IDXSET_FOREACH(sink, core->sinks, idx) {
         if (!PA_SINK_IS_LINKED(sink->state))
@@ -330,6 +330,8 @@ void pa_core_update_default_sink(pa_core *core) {
         if (compare_sinks(sink, best) > 0)
             best = sink;
     }
+
+    old = core->default_sink;
 
     if (best == old)
         return;
@@ -396,12 +398,12 @@ static int compare_sources(pa_source *a, pa_source *b) {
 }
 
 void pa_core_update_default_source(pa_core *core) {
-    pa_source *best, *old, *source;
+    pa_source *best = NULL;
+    pa_source *source;
     uint32_t idx;
+    pa_source *old;
 
     pa_assert(core);
-
-    best = old = core->default_source;
 
     PA_IDXSET_FOREACH(source, core->sources, idx) {
         if (!PA_SOURCE_IS_LINKED(source->state))
@@ -415,6 +417,8 @@ void pa_core_update_default_source(pa_core *core) {
         if (compare_sources(source, best) > 0)
             best = source;
     }
+
+    old = core->default_source;
 
     if (best == old)
         return;

--- a/src/pulsecore/core.c
+++ b/src/pulsecore/core.c
@@ -314,7 +314,7 @@ void pa_core_update_default_sink(pa_core *core) {
     pa_sink *best = NULL;
     pa_sink *sink;
     uint32_t idx;
-    pa_sink *old;
+    pa_sink *old_default_sink;
 
     pa_assert(core);
 
@@ -331,14 +331,14 @@ void pa_core_update_default_sink(pa_core *core) {
             best = sink;
     }
 
-    old = core->default_sink;
+    old_default_sink = core->default_sink;
 
-    if (best == old)
+    if (best == old_default_sink)
         return;
 
     core->default_sink = best;
     pa_log_info("default_sink: %s -> %s",
-                old ? old->name : "(unset)", best ? best->name : "(unset)");
+                old_default_sink ? old_default_sink->name : "(unset)", best ? best->name : "(unset)");
 
     /* If the default sink changed, it may be that the default source has to be
      * changed too, because monitor sources are prioritized partly based on the
@@ -401,7 +401,7 @@ void pa_core_update_default_source(pa_core *core) {
     pa_source *best = NULL;
     pa_source *source;
     uint32_t idx;
-    pa_source *old;
+    pa_source *old_default_source;
 
     pa_assert(core);
 
@@ -418,14 +418,14 @@ void pa_core_update_default_source(pa_core *core) {
             best = source;
     }
 
-    old = core->default_source;
+    old_default_source = core->default_source;
 
-    if (best == old)
+    if (best == old_default_source)
         return;
 
     core->default_source = best;
     pa_log_info("default_source: %s -> %s",
-                old ? old->name : "(unset)", best ? best->name : "(unset)");
+                old_default_source ? old_default_source->name : "(unset)", best ? best->name : "(unset)");
     pa_subscription_post(core, PA_SUBSCRIPTION_EVENT_SERVER | PA_SUBSCRIPTION_EVENT_CHANGE, PA_INVALID_INDEX);
     pa_hook_fire(&core->hooks[PA_CORE_HOOK_DEFAULT_SOURCE_CHANGED], core->default_source);
 }


### PR DESCRIPTION
The initial best choice in pa_core_update_default_{sink,source} should
only be the current default if it is linked, otherwise we will not be
able to unset the default when freeing the last sink or source.

https://phabricator.endlessm.com/T26860