### PR TITLE
alsa-mixer: Drop HDMI surround profiles

### DIFF
--- a/src/modules/alsa/mixer/profile-sets/default.conf
+++ b/src/modules/alsa/mixer/profile-sets/default.conf
@@ -205,22 +205,6 @@ channel-map = left,right
 priority = 9
 direction = output
 
-[Mapping hdmi-surround]
-description = Digital Surround 5.1 (HDMI)
-device-strings = hdmi:%f
-paths-output = hdmi-output-0
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
-priority = 8
-direction = output
-
-[Mapping hdmi-surround71]
-description = Digital Surround 7.1 (HDMI)
-device-strings = hdmi:%f
-paths-output = hdmi-output-0
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
-priority = 8
-direction = output
-
 [Mapping hdmi-dts-surround]
 description = Digital Surround 5.1 (HDMI/DTS)
 device-strings = dcahdmi:%f
@@ -235,22 +219,6 @@ device-strings = hdmi:%f,1
 paths-output = hdmi-output-1
 channel-map = left,right
 priority = 7
-direction = output
-
-[Mapping hdmi-surround-extra1]
-description = Digital Surround 5.1 (HDMI 2)
-device-strings = hdmi:%f,1
-paths-output = hdmi-output-1
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
-priority = 6
-direction = output
-
-[Mapping hdmi-surround71-extra1]
-description = Digital Surround 7.1 (HDMI 2)
-device-strings = hdmi:%f,1
-paths-output = hdmi-output-1
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
-priority = 6
 direction = output
 
 [Mapping hdmi-dts-surround-extra1]
@@ -269,22 +237,6 @@ channel-map = left,right
 priority = 7
 direction = output
 
-[Mapping hdmi-surround-extra2]
-description = Digital Surround 5.1 (HDMI 3)
-device-strings = hdmi:%f,2
-paths-output = hdmi-output-2
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
-priority = 6
-direction = output
-
-[Mapping hdmi-surround71-extra2]
-description = Digital Surround 7.1 (HDMI 3)
-device-strings = hdmi:%f,2
-paths-output = hdmi-output-2
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
-priority = 6
-direction = output
-
 [Mapping hdmi-dts-surround-extra2]
 description = Digital Surround 5.1 (HDMI 3/DTS)
 device-strings = dcahdmi:%f,2
@@ -299,22 +251,6 @@ device-strings = hdmi:%f,3
 paths-output = hdmi-output-3
 channel-map = left,right
 priority = 7
-direction = output
-
-[Mapping hdmi-surround-extra3]
-description = Digital Surround 5.1 (HDMI 4)
-device-strings = hdmi:%f,3
-paths-output = hdmi-output-3
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
-priority = 6
-direction = output
-
-[Mapping hdmi-surround71-extra3]
-description = Digital Surround 7.1 (HDMI 4)
-device-strings = hdmi:%f,3
-paths-output = hdmi-output-3
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
-priority = 6
 direction = output
 
 [Mapping hdmi-dts-surround-extra3]
@@ -333,22 +269,6 @@ channel-map = left,right
 priority = 7
 direction = output
 
-[Mapping hdmi-surround-extra4]
-description = Digital Surround 5.1 (HDMI 5)
-device-strings = hdmi:%f,4
-paths-output = hdmi-output-4
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
-priority = 6
-direction = output
-
-[Mapping hdmi-surround71-extra4]
-description = Digital Surround 7.1 (HDMI 5)
-device-strings = hdmi:%f,4
-paths-output = hdmi-output-4
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
-priority = 6
-direction = output
-
 [Mapping hdmi-dts-surround-extra4]
 description = Digital Surround 5.1 (HDMI 5/DTS)
 device-strings = dcahdmi:%f,4
@@ -363,22 +283,6 @@ device-strings = hdmi:%f,5
 paths-output = hdmi-output-5
 channel-map = left,right
 priority = 7
-direction = output
-
-[Mapping hdmi-surround-extra5]
-description = Digital Surround 5.1 (HDMI 6)
-device-strings = hdmi:%f,5
-paths-output = hdmi-output-5
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
-priority = 6
-direction = output
-
-[Mapping hdmi-surround71-extra5]
-description = Digital Surround 7.1 (HDMI 6)
-device-strings = hdmi:%f,5
-paths-output = hdmi-output-5
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
-priority = 6
 direction = output
 
 [Mapping hdmi-dts-surround-extra5]
@@ -397,22 +301,6 @@ channel-map = left,right
 priority = 7
 direction = output
 
-[Mapping hdmi-surround-extra6]
-description = Digital Surround 5.1 (HDMI 7)
-device-strings = hdmi:%f,6
-paths-output = hdmi-output-6
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
-priority = 6
-direction = output
-
-[Mapping hdmi-surround71-extra6]
-description = Digital Surround 7.1 (HDMI 7)
-device-strings = hdmi:%f,6
-paths-output = hdmi-output-6
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
-priority = 6
-direction = output
-
 [Mapping hdmi-dts-surround-extra6]
 description = Digital Surround 5.1 (HDMI 7/DTS)
 device-strings = dcahdmi:%f,6
@@ -427,22 +315,6 @@ device-strings = hdmi:%f,7
 paths-output = hdmi-output-7
 channel-map = left,right
 priority = 7
-direction = output
-
-[Mapping hdmi-surround-extra7]
-description = Digital Surround 5.1 (HDMI 8)
-device-strings = hdmi:%f,7
-paths-output = hdmi-output-7
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
-priority = 6
-direction = output
-
-[Mapping hdmi-surround71-extra7]
-description = Digital Surround 7.1 (HDMI 8)
-device-strings = hdmi:%f,7
-paths-output = hdmi-output-7
-channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
-priority = 6
 direction = output
 
 [Mapping hdmi-dts-surround-extra7]


### PR DESCRIPTION
When an ALSA card is created, the card initialization code tried to open
the ALSA device with all channel configurations corresponding to every
profile listed in the corresponding profile-sets configuraion file, to
learn what is supported. If no HDMI cable is connected at that point,
the ALSA reports the surround 5.1 and 7.1 profiles as supported, and
that information is kept through the lifetime of the card.

Later when an audio-capable device is connected and the HDMI port
becomes available, the surround profiles are also marked as available.
But if the device attached on the other end of the HDMI cable does not
support that channel configuration, selecting one of the surround
profiles results in snd_pcm_hw_params_set_channels() failing, which
leaves the profile without a sink. Despite the profile change being
perceived as successful by the core and module-alsa-card, all
sink-outputs get moved to the NULL sink (assuming module-always-sink and
module-rescue-streams are active) and the user have no sound.

Disabling support for the hdmi-surround* profiles avoids this problem.

https://phabricator.endlessm.com/T27179