### PR TITLE
alsa-card: Remain functional after profile change failure

### DIFF
--- a/src/modules/alsa/mixer/profile-sets/default.conf
+++ b/src/modules/alsa/mixer/profile-sets/default.conf
@@ -205,6 +205,22 @@ channel-map = left,right
 priority = 9
 direction = output
 
+[Mapping hdmi-surround]
+description = Digital Surround 5.1 (HDMI)
+device-strings = hdmi:%f
+paths-output = hdmi-output-0
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 8
+direction = output
+
+[Mapping hdmi-surround71]
+description = Digital Surround 7.1 (HDMI)
+device-strings = hdmi:%f
+paths-output = hdmi-output-0
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 8
+direction = output
+
 [Mapping hdmi-dts-surround]
 description = Digital Surround 5.1 (HDMI/DTS)
 device-strings = dcahdmi:%f
@@ -219,6 +235,22 @@ device-strings = hdmi:%f,1
 paths-output = hdmi-output-1
 channel-map = left,right
 priority = 7
+direction = output
+
+[Mapping hdmi-surround-extra1]
+description = Digital Surround 5.1 (HDMI 2)
+device-strings = hdmi:%f,1
+paths-output = hdmi-output-1
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Mapping hdmi-surround71-extra1]
+description = Digital Surround 7.1 (HDMI 2)
+device-strings = hdmi:%f,1
+paths-output = hdmi-output-1
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
 direction = output
 
 [Mapping hdmi-dts-surround-extra1]
@@ -237,6 +269,22 @@ channel-map = left,right
 priority = 7
 direction = output
 
+[Mapping hdmi-surround-extra2]
+description = Digital Surround 5.1 (HDMI 3)
+device-strings = hdmi:%f,2
+paths-output = hdmi-output-2
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Mapping hdmi-surround71-extra2]
+description = Digital Surround 7.1 (HDMI 3)
+device-strings = hdmi:%f,2
+paths-output = hdmi-output-2
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
+direction = output
+
 [Mapping hdmi-dts-surround-extra2]
 description = Digital Surround 5.1 (HDMI 3/DTS)
 device-strings = dcahdmi:%f,2
@@ -251,6 +299,22 @@ device-strings = hdmi:%f,3
 paths-output = hdmi-output-3
 channel-map = left,right
 priority = 7
+direction = output
+
+[Mapping hdmi-surround-extra3]
+description = Digital Surround 5.1 (HDMI 4)
+device-strings = hdmi:%f,3
+paths-output = hdmi-output-3
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Mapping hdmi-surround71-extra3]
+description = Digital Surround 7.1 (HDMI 4)
+device-strings = hdmi:%f,3
+paths-output = hdmi-output-3
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
 direction = output
 
 [Mapping hdmi-dts-surround-extra3]
@@ -269,6 +333,22 @@ channel-map = left,right
 priority = 7
 direction = output
 
+[Mapping hdmi-surround-extra4]
+description = Digital Surround 5.1 (HDMI 5)
+device-strings = hdmi:%f,4
+paths-output = hdmi-output-4
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Mapping hdmi-surround71-extra4]
+description = Digital Surround 7.1 (HDMI 5)
+device-strings = hdmi:%f,4
+paths-output = hdmi-output-4
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
+direction = output
+
 [Mapping hdmi-dts-surround-extra4]
 description = Digital Surround 5.1 (HDMI 5/DTS)
 device-strings = dcahdmi:%f,4
@@ -283,6 +363,22 @@ device-strings = hdmi:%f,5
 paths-output = hdmi-output-5
 channel-map = left,right
 priority = 7
+direction = output
+
+[Mapping hdmi-surround-extra5]
+description = Digital Surround 5.1 (HDMI 6)
+device-strings = hdmi:%f,5
+paths-output = hdmi-output-5
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Mapping hdmi-surround71-extra5]
+description = Digital Surround 7.1 (HDMI 6)
+device-strings = hdmi:%f,5
+paths-output = hdmi-output-5
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
 direction = output
 
 [Mapping hdmi-dts-surround-extra5]
@@ -301,6 +397,22 @@ channel-map = left,right
 priority = 7
 direction = output
 
+[Mapping hdmi-surround-extra6]
+description = Digital Surround 5.1 (HDMI 7)
+device-strings = hdmi:%f,6
+paths-output = hdmi-output-6
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Mapping hdmi-surround71-extra6]
+description = Digital Surround 7.1 (HDMI 7)
+device-strings = hdmi:%f,6
+paths-output = hdmi-output-6
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
+direction = output
+
 [Mapping hdmi-dts-surround-extra6]
 description = Digital Surround 5.1 (HDMI 7/DTS)
 device-strings = dcahdmi:%f,6
@@ -315,6 +427,22 @@ device-strings = hdmi:%f,7
 paths-output = hdmi-output-7
 channel-map = left,right
 priority = 7
+direction = output
+
+[Mapping hdmi-surround-extra7]
+description = Digital Surround 5.1 (HDMI 8)
+device-strings = hdmi:%f,7
+paths-output = hdmi-output-7
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe
+priority = 6
+direction = output
+
+[Mapping hdmi-surround71-extra7]
+description = Digital Surround 7.1 (HDMI 8)
+device-strings = hdmi:%f,7
+paths-output = hdmi-output-7
+channel-map = front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+priority = 6
 direction = output
 
 [Mapping hdmi-dts-surround-extra7]


### PR DESCRIPTION
When setting a new profile, try to create the new sinks and sources
before destroying old ones, so if the creation fails the card is not
left without a sink or source.

https://phabricator.endlessm.com/T27395