### PR TITLE
Fix concurrency between GDM's and user's PulseAudio registering HSP support

### DIFF
--- a/src/modules/bluetooth/backend-native.c
+++ b/src/modules/bluetooth/backend-native.c
@@ -293,16 +293,16 @@ static void register_profile_reply(DBusPendingCall *pending, void *userdata) {
     DBusMessage *r;
     pa_dbus_pending *p;
     pa_bluetooth_backend *b;
-    char *object;
+    pa_bluetooth_profile_t profile;
 
     pa_assert(pending);
     pa_assert_se(p = userdata);
     pa_assert_se(b = p->context_data);
-    pa_assert_se(object = p->call_data);
+    pa_assert_se(profile = (pa_bluetooth_profile_t)p->call_data);
     pa_assert_se(r = dbus_pending_call_steal_reply(pending));
 
     if (dbus_message_is_error(r, BLUEZ_ERROR_NOT_SUPPORTED)) {
-        pa_log_info("Couldn't register object %s because its profile is disabled in BlueZ", object);
+        pa_log_info("Couldn't register profile %s because it is disabled in BlueZ", pa_bluetooth_profile_to_string(profile));
         goto finish;
     }
 
@@ -317,17 +317,15 @@ finish:
 
     PA_LLIST_REMOVE(pa_dbus_pending, b->pending, p);
     pa_dbus_pending_free(p);
-
-    pa_xfree(object);
 }
 
-static void register_profile(pa_bluetooth_backend *b, const char *object, const char *uuid) {
+static void register_profile(pa_bluetooth_backend *b, const char *object, const char *uuid, pa_bluetooth_profile_t profile) {
     DBusMessage *m;
     DBusMessageIter i, d;
     dbus_bool_t autoconnect;
     dbus_uint16_t version, chan;
 
-    pa_log_debug("Registering Profile %s %s", object, uuid);
+    pa_log_debug("Registering Profile %s %s", pa_bluetooth_profile_to_string(profile), uuid);
 
     pa_assert_se(m = dbus_message_new_method_call(BLUEZ_SERVICE, "/org/bluez", BLUEZ_PROFILE_MANAGER_INTERFACE, "RegisterProfile"));
 
@@ -348,7 +346,7 @@ static void register_profile(pa_bluetooth_backend *b, const char *object, const 
     }
     dbus_message_iter_close_container(&i, &d);
 
-    send_and_add_to_pending(b, m, register_profile_reply, pa_xstrdup(object));
+    send_and_add_to_pending(b, m, register_profile_reply, (void *)profile);
 }
 
 static void rfcomm_io_callback(pa_mainloop_api *io, pa_io_event *e, int fd, pa_io_event_flags_t events, void *userdata) {
@@ -640,7 +638,7 @@ static void profile_init(pa_bluetooth_backend *b, pa_bluetooth_profile_t profile
     }
 
     pa_assert_se(dbus_connection_register_object_path(pa_dbus_connection_get(b->connection), object_name, &vtable_profile, b));
-    register_profile(b, object_name, uuid);
+    register_profile(b, object_name, uuid, profile);
 }
 
 static void profile_done(pa_bluetooth_backend *b, pa_bluetooth_profile_t profile) {

--- a/src/modules/bluetooth/backend-native.c
+++ b/src/modules/bluetooth/backend-native.c
@@ -293,16 +293,16 @@ static void register_profile_reply(DBusPendingCall *pending, void *userdata) {
     DBusMessage *r;
     pa_dbus_pending *p;
     pa_bluetooth_backend *b;
-    char *profile;
+    char *object;
 
     pa_assert(pending);
     pa_assert_se(p = userdata);
     pa_assert_se(b = p->context_data);
-    pa_assert_se(profile = p->call_data);
+    pa_assert_se(object = p->call_data);
     pa_assert_se(r = dbus_pending_call_steal_reply(pending));
 
     if (dbus_message_is_error(r, BLUEZ_ERROR_NOT_SUPPORTED)) {
-        pa_log_info("Couldn't register profile %s because it is disabled in BlueZ", profile);
+        pa_log_info("Couldn't register object %s because its profile is disabled in BlueZ", object);
         goto finish;
     }
 
@@ -318,21 +318,21 @@ finish:
     PA_LLIST_REMOVE(pa_dbus_pending, b->pending, p);
     pa_dbus_pending_free(p);
 
-    pa_xfree(profile);
+    pa_xfree(object);
 }
 
-static void register_profile(pa_bluetooth_backend *b, const char *profile, const char *uuid) {
+static void register_profile(pa_bluetooth_backend *b, const char *object, const char *uuid) {
     DBusMessage *m;
     DBusMessageIter i, d;
     dbus_bool_t autoconnect;
     dbus_uint16_t version, chan;
 
-    pa_log_debug("Registering Profile %s %s", profile, uuid);
+    pa_log_debug("Registering Profile %s %s", object, uuid);
 
     pa_assert_se(m = dbus_message_new_method_call(BLUEZ_SERVICE, "/org/bluez", BLUEZ_PROFILE_MANAGER_INTERFACE, "RegisterProfile"));
 
     dbus_message_iter_init_append(m, &i);
-    pa_assert_se(dbus_message_iter_append_basic(&i, DBUS_TYPE_OBJECT_PATH, &profile));
+    pa_assert_se(dbus_message_iter_append_basic(&i, DBUS_TYPE_OBJECT_PATH, &object));
     pa_assert_se(dbus_message_iter_append_basic(&i, DBUS_TYPE_STRING, &uuid));
     dbus_message_iter_open_container(&i, DBUS_TYPE_ARRAY, DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING DBUS_TYPE_STRING_AS_STRING
             DBUS_TYPE_VARIANT_AS_STRING DBUS_DICT_ENTRY_END_CHAR_AS_STRING, &d);
@@ -348,7 +348,7 @@ static void register_profile(pa_bluetooth_backend *b, const char *profile, const
     }
     dbus_message_iter_close_container(&i, &d);
 
-    send_and_add_to_pending(b, m, register_profile_reply, pa_xstrdup(profile));
+    send_and_add_to_pending(b, m, register_profile_reply, pa_xstrdup(object));
 }
 
 static void rfcomm_io_callback(pa_mainloop_api *io, pa_io_event *e, int fd, pa_io_event_flags_t events, void *userdata) {

--- a/src/modules/bluetooth/bluez5-util.c
+++ b/src/modules/bluetooth/bluez5-util.c
@@ -904,6 +904,7 @@ static void parse_adapter_properties(pa_bluetooth_adapter *a, DBusMessageIter *i
                     pa_log_debug("%s: %s", key, value);
                     dbus_message_iter_next(&ai);
                 }
+                pa_hook_fire(pa_bluetooth_discovery_hook(a->discovery, PA_BLUETOOTH_HOOK_ADAPTER_UUIDS_CHANGED), a);
             }
         }
 

--- a/src/modules/bluetooth/bluez5-util.c
+++ b/src/modules/bluetooth/bluez5-util.c
@@ -90,6 +90,7 @@ struct pa_bluetooth_discovery {
     pa_hashmap *adapters;
     pa_hashmap *devices;
     pa_hashmap *transports;
+    pa_bluetooth_profile_status_t profiles_status[PA_BLUETOOTH_PROFILE_COUNT];
 
     pa_hashmap *disabled_profiles; /* pa_bluetooth_profile_t -> pa_bluetooth_profile_t (hashmap-as-a-set) */
 
@@ -138,6 +139,14 @@ static const char *check_variant_property(DBusMessageIter *i) {
     }
 
     return key;
+}
+
+pa_bluetooth_profile_status_t profile_status_get(pa_bluetooth_discovery *y, pa_bluetooth_profile_t profile) {
+    return y->profiles_status[profile];
+}
+
+void profile_status_set(pa_bluetooth_discovery *y, pa_bluetooth_profile_t profile, pa_bluetooth_profile_status_t status) {
+    y->profiles_status[profile] = status;
 }
 
 pa_bluetooth_transport *pa_bluetooth_transport_new(pa_bluetooth_device *d, const char *owner, const char *path,

--- a/src/modules/bluetooth/bluez5-util.h
+++ b/src/modules/bluetooth/bluez5-util.h
@@ -59,6 +59,13 @@ typedef enum profile {
 } pa_bluetooth_profile_t;
 #define PA_BLUETOOTH_PROFILE_COUNT PA_BLUETOOTH_PROFILE_OFF
 
+typedef enum pa_bluetooth_profile_status {
+  PA_BLUETOOTH_PROFILE_STATUS_INACTIVE,
+  PA_BLUETOOTH_PROFILE_STATUS_ACTIVE,
+  PA_BLUETOOTH_PROFILE_STATUS_REGISTERING,
+  PA_BLUETOOTH_PROFILE_STATUS_REGISTERED
+} pa_bluetooth_profile_status_t;
+
 typedef enum pa_bluetooth_transport_state {
     PA_BLUETOOTH_TRANSPORT_STATE_DISCONNECTED,
     PA_BLUETOOTH_TRANSPORT_STATE_IDLE,
@@ -147,6 +154,9 @@ static inline pa_bluetooth_backend *pa_bluetooth_native_backend_new(pa_core *c, 
 static inline void pa_bluetooth_native_backend_free(pa_bluetooth_backend *b) {}
 static inline void pa_bluetooth_native_backend_enable_hs_role(pa_bluetooth_backend *b, bool enable_hs_role) {}
 #endif
+
+pa_bluetooth_profile_status_t profile_status_get(pa_bluetooth_discovery *y, pa_bluetooth_profile_t profile);
+void profile_status_set(pa_bluetooth_discovery *y, pa_bluetooth_profile_t profile, pa_bluetooth_profile_status_t status);
 
 pa_bluetooth_transport *pa_bluetooth_transport_new(pa_bluetooth_device *d, const char *owner, const char *path,
                                                    pa_bluetooth_profile_t p, const uint8_t *config, size_t size);

--- a/src/modules/bluetooth/bluez5-util.h
+++ b/src/modules/bluetooth/bluez5-util.h
@@ -43,6 +43,7 @@ typedef struct pa_bluetooth_discovery pa_bluetooth_discovery;
 typedef struct pa_bluetooth_backend pa_bluetooth_backend;
 
 typedef enum pa_bluetooth_hook {
+    PA_BLUETOOTH_HOOK_ADAPTER_UUIDS_CHANGED,              /* Call data: pa_bluetooth_adapter */
     PA_BLUETOOTH_HOOK_DEVICE_CONNECTION_CHANGED,          /* Call data: pa_bluetooth_device */
     PA_BLUETOOTH_HOOK_TRANSPORT_STATE_CHANGED,            /* Call data: pa_bluetooth_transport */
     PA_BLUETOOTH_HOOK_TRANSPORT_MICROPHONE_GAIN_CHANGED,  /* Call data: pa_bluetooth_transport */


### PR DESCRIPTION
This, together with a change in BlueZ to report RegisterProfile failure to the caller, handles the case when PulseAudio tries to register a profile implementation that has already been registered previously by a different caller.

https://phabricator.endlessm.com/T27536