### PR TITLE
backend-native: Free adapter_uuids_changed_slot in pa_bluetooth_native_backend_free

### DIFF
--- a/src/modules/bluetooth/backend-native.c
+++ b/src/modules/bluetooth/backend-native.c
@@ -40,6 +40,7 @@ struct pa_bluetooth_backend {
   pa_core *core;
   pa_dbus_connection *connection;
   pa_bluetooth_discovery *discovery;
+  pa_hook_slot *adapter_uuids_changed_slot;
   bool enable_hs_role;
 
   PA_LLIST_HEAD(pa_dbus_pending, pending);
@@ -720,8 +721,9 @@ pa_bluetooth_backend *pa_bluetooth_native_backend_new(pa_core *c, pa_bluetooth_d
     backend->discovery = y;
     backend->enable_hs_role = enable_hs_role;
 
-    pa_hook_connect(pa_bluetooth_discovery_hook(y, PA_BLUETOOTH_HOOK_ADAPTER_UUIDS_CHANGED), PA_HOOK_NORMAL,
-                    (pa_hook_cb_t) adapter_uuids_changed_cb, backend);
+    backend->adapter_uuids_changed_slot =
+        pa_hook_connect(pa_bluetooth_discovery_hook(y, PA_BLUETOOTH_HOOK_ADAPTER_UUIDS_CHANGED), PA_HOOK_NORMAL,
+                        (pa_hook_cb_t) adapter_uuids_changed_cb, backend);
 
     if (enable_hs_role)
        profile_init(backend, PA_BLUETOOTH_PROFILE_HEADSET_AUDIO_GATEWAY);
@@ -734,6 +736,9 @@ void pa_bluetooth_native_backend_free(pa_bluetooth_backend *backend) {
     pa_assert(backend);
 
     pa_dbus_free_pending_list(&backend->pending);
+
+    if (backend->adapter_uuids_changed_slot)
+        pa_hook_slot_free(backend->adapter_uuids_changed_slot);
 
     if (backend->enable_hs_role)
        profile_done(backend, PA_BLUETOOTH_PROFILE_HEADSET_AUDIO_GATEWAY);

--- a/src/modules/bluetooth/backend-native.c
+++ b/src/modules/bluetooth/backend-native.c
@@ -623,18 +623,19 @@ static DBusHandlerResult profile_handler(DBusConnection *c, DBusMessage *m, void
 }
 
 static pa_hook_result_t adapter_uuids_changed_cb(pa_bluetooth_discovery *y, const pa_bluetooth_adapter *a, pa_bluetooth_backend *b) {
+    pa_assert(y);
     pa_assert(a);
     pa_assert(b);
 
-    if (profile_status_get(b->discovery, PA_BLUETOOTH_PROFILE_HEADSET_HEAD_UNIT) <= PA_BLUETOOTH_PROFILE_STATUS_INACTIVE &&
-        profile_status_get(b->discovery, PA_BLUETOOTH_PROFILE_HEADSET_AUDIO_GATEWAY) <= PA_BLUETOOTH_PROFILE_STATUS_INACTIVE)
+    if (profile_status_get(y, PA_BLUETOOTH_PROFILE_HEADSET_HEAD_UNIT) <= PA_BLUETOOTH_PROFILE_STATUS_INACTIVE &&
+        profile_status_get(y, PA_BLUETOOTH_PROFILE_HEADSET_AUDIO_GATEWAY) <= PA_BLUETOOTH_PROFILE_STATUS_INACTIVE)
         return PA_HOOK_OK;
 
-    if (profile_status_get(b->discovery, PA_BLUETOOTH_PROFILE_HEADSET_HEAD_UNIT) == PA_BLUETOOTH_PROFILE_STATUS_ACTIVE &&
+    if (profile_status_get(y, PA_BLUETOOTH_PROFILE_HEADSET_HEAD_UNIT) == PA_BLUETOOTH_PROFILE_STATUS_ACTIVE &&
         !pa_hashmap_get(a->uuids, PA_BLUETOOTH_UUID_HSP_AG))
         register_profile(b, HSP_AG_PROFILE, PA_BLUETOOTH_UUID_HSP_AG, PA_BLUETOOTH_PROFILE_HEADSET_HEAD_UNIT);
 
-    if (profile_status_get(b->discovery, PA_BLUETOOTH_PROFILE_HEADSET_AUDIO_GATEWAY) == PA_BLUETOOTH_PROFILE_STATUS_ACTIVE &&
+    if (profile_status_get(y, PA_BLUETOOTH_PROFILE_HEADSET_AUDIO_GATEWAY) == PA_BLUETOOTH_PROFILE_STATUS_ACTIVE &&
         !pa_hashmap_get(a->uuids, PA_BLUETOOTH_UUID_HSP_HS))
         register_profile(b, HSP_HS_PROFILE, PA_BLUETOOTH_UUID_HSP_HS, PA_BLUETOOTH_PROFILE_HEADSET_AUDIO_GATEWAY);
 


### PR DESCRIPTION
Free the slot for PA_BLUETOOTH_HOOK_ADAPTER_UUIDS_CHANGED when the backend is freed, otherwise the hook stays registered and if blueoothd disappears from the bus and re-appears later, it gets called with the address of the old pa_bluetooth_backend struct as the slot data pointer, which crashes PulseAudio with a SIGSEGV.

https://phabricator.endlessm.com/T27536
