### PR TITLE
fixup! bluetooth: Disable profiles on specific product ids

### DIFF
--- a/src/modules/bluetooth/bluez5-util.c
+++ b/src/modules/bluetooth/bluez5-util.c
@@ -1868,7 +1868,7 @@ static void check_hw_disabled_profiles(pa_bluetooth_discovery *y) {
     char *id = get_product_id();
 
     while (hw_disabled_profiles[i].product_id) {
-        if (pa_streq(id, hw_disabled_profiles[i].product_id)) {
+        if (pa_safe_streq(id, hw_disabled_profiles[i].product_id)) {
             pa_bluetooth_profile_t p = hw_disabled_profiles[i].profile;
             pa_log_debug("Disabling Bluetooth profile \"%s\" on %s", pa_bluetooth_profile_to_string(p), id);
             pa_hashmap_put(y->disabled_profiles, PA_UINT32_TO_PTR(p), PA_UINT32_TO_PTR(p));


### PR DESCRIPTION
This leads to a crash on the RPi4 since we fail to identify the product
id (so id is NULL).

https://phabricator.endlessm.com/T29065